### PR TITLE
Added Gemfile and fixed android script for latest appium_lib

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# gem "rails"
+
+gem "appium_lib", "~> 16.1"
+
+gem "selenium-webdriver", "~> 4.40"
+
+gem "test-unit", "~> 3.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,66 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    appium_lib (16.1.1)
+      appium_lib_core (>= 9.2.1, < 12.0)
+      nokogiri (~> 1.8, >= 1.8.1)
+      tomlrb (>= 1.1, < 3.0)
+    appium_lib_core (11.2.0)
+      faye-websocket (>= 0.11, < 0.13)
+      selenium-webdriver (~> 4.21)
+    base64 (0.3.0)
+    eventmachine (1.2.7)
+    faye-websocket (0.12.0)
+      eventmachine (>= 0.12.0)
+      websocket-driver (>= 0.8.0)
+    logger (1.7.0)
+    nokogiri (1.19.0-x64-mingw-ucrt)
+      racc (~> 1.4)
+    power_assert (3.0.1)
+    racc (1.8.1)
+    rexml (3.4.4)
+    rubyzip (3.2.2)
+    selenium-webdriver (4.40.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 4.0)
+      websocket (~> 1.0)
+    test-unit (3.7.7)
+      power_assert
+    tomlrb (2.0.4)
+    websocket (1.2.11)
+    websocket-driver (0.8.0)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+
+PLATFORMS
+  x64-mingw-ucrt
+
+DEPENDENCIES
+  appium_lib (~> 16.1)
+  selenium-webdriver (~> 4.40)
+  test-unit (~> 3.7)
+
+CHECKSUMS
+  appium_lib (16.1.1) sha256=d53402b41846c1e1431ed44ba49cb7c9ff8f56f2a51c433b57f167b68afe9cb7
+  appium_lib_core (11.2.0) sha256=677040cceb7ff5e07276df55791106fee398101b69e82edf9e382a6609d18a70
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  eventmachine (1.2.7) sha256=994016e42aa041477ba9cff45cbe50de2047f25dd418eba003e84f0d16560972
+  faye-websocket (0.12.0) sha256=ad9f7dfcd0306d0a13baeee450729657661129af15bb5f38716c242484ab42e1
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  nokogiri (1.19.0-x64-mingw-ucrt) sha256=05d7ed2d95731edc9bef2811522dc396df3e476ef0d9c76793a9fca81cab056b
+  power_assert (3.0.1) sha256=8ce9876716cc74e863fcd4cdcdc52d792bd983598d1af3447083a3a9a4d34103
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubyzip (3.2.2) sha256=c0ed99385f0625415c8f05bcae33fe649ed2952894a95ff8b08f26ca57ea5b3c
+  selenium-webdriver (4.40.0) sha256=16ef7aa9853c1d4b9d52eac45aafa916e3934c5c83cb4facb03f250adfd15e5b
+  test-unit (3.7.7) sha256=3c89d5ff0690a16bef9946156c4624390402b9d54dfcf4ce9cbd5b06bead1e45
+  tomlrb (2.0.4) sha256=262f77947ac3ac9b3366a0a5940ecd238300c553e2e14f22009e2afcd2181b99
+  websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737
+  websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
+  websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
+
+BUNDLED WITH
+  4.0.5

--- a/README.md
+++ b/README.md
@@ -47,17 +47,19 @@ Before you can start performing Ruby automation testing with Appium, you would n
    git clone [https://github.com/Priya2224/LT-appium-ruby.git](https://github.com/Priya2224/LT-appium-ruby.git)
    cd LT-appium-ruby
 
+## Setting Up Your Authentication
 
-Setting Up Your Authentication
 Make sure you have your LambdaTest credentials with you to run test automation scripts. To obtain your access credentials, purchase a plan or access the Automation Dashboard.
 
 Set LambdaTest Username and Access Key in environment variables.
 
-For Linux/macOS:
-export LT_USERNAME=YOUR_LAMBDATEST_USERNAME \
+1. **For Linux/macOS**:
+```bash
+export LT_USERNAME=YOUR_LAMBDATEST_USERNAME
 export LT_ACCESS_KEY=YOUR_LAMBDATEST_ACCESS_KEY
 
-For Windows:
+2. **For Windows**:
+```bash
 set LT_USERNAME=YOUR_LAMBDATEST_USERNAME
 set LT_ACCESS_KEY=YOUR_LAMBDATEST_ACCESS_KEY
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@
   <a href="https://www.youtube.com/c/LambdaTest" target="_bank">YouTube</a>
 </p>
 
-*Appium is a tool for automating native, mobile web, and hybrid applications on iOS, Android, and Windows platforms. Perform Appium automation tests on [LambdaTest's online cloud](https://www.lambdatest.com/appium-mobile-testing).*
+*Appium is a tool for automating native, mobile web, and hybrid applications on iOS, Android, and Windows platforms. It supports iOS native apps written in Objective-C or Swift and Android native apps written in Java or Kotlin. It also supports mobile web apps accessed using a mobile browser (Appium supports Safari on iOS and Chrome or the built-in 'Browser' app on Android). Perform Appium automation tests on [LambdaTest's online cloud](https://www.lambdatest.com/appium-mobile-testing).*
+
+Learn the basics of [Appium testing on the LambdaTest platform](https://www.lambdatest.com/support/docs/getting-started-with-appium-testing/).
 
 [<img height="53" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
 
@@ -38,134 +40,240 @@
 
 Before you can start performing Ruby automation testing with Appium, you would need to:
 
-1. **Install Ruby**: Ensure you have Ruby 3.4+ installed.
+1. Install **Ruby**: Ensure you have Ruby 3.4+ installed.
+
    - For **Windows**, download from [RubyInstaller](https://rubyinstaller.org/downloads/).
    - For **macOS**, run `brew install ruby`.
+   - For **Linux** or **Ubuntu**, you can run a simple apt command like below:
+     sudo apt-get install ruby-full
 
 2. **Clone The Sample Project**:
-   ```bash
-   git clone [https://github.com/Priya2224/LT-appium-ruby.git](https://github.com/Priya2224/LT-appium-ruby.git)
-   cd LT-appium-ruby
+
+```bash
+git clone [https://github.com/Priya2224/LT-appium-ruby.git](https://github.com/Priya2224/LT-appium-ruby.git)
+cd LT-appium-ruby
+
+```
 
 ## Setting Up Your Authentication
 
-Make sure you have your LambdaTest credentials with you to run test automation scripts. To obtain your access credentials, purchase a plan or access the Automation Dashboard.
+Make sure you have your LambdaTest credentials with you to run test automation scripts. To obtain your access credentials, purchase a plan or access the access the [App Automation Dashboard](https://appautomation.lambdatest.com/)
 
 Set LambdaTest Username and Access Key in environment variables.
 
-1. **For Linux/macOS**:
+For Linux/macOS:
+
 ```bash
 export LT_USERNAME=YOUR_LAMBDATEST_USERNAME
 export LT_ACCESS_KEY=YOUR_LAMBDATEST_ACCESS_KEY
+```
 
-2. **For Windows**:
+For Windows:
+
 ```bash
 set LT_USERNAME=YOUR_LAMBDATEST_USERNAME
 set LT_ACCESS_KEY=YOUR_LAMBDATEST_ACCESS_KEY
+```
 
+## Upload Your Application
 
-Upload Your Application
-Upload your iOS application (.ipa file) or android application (.apk file) to the LambdaTest servers using our REST API.
+Upload your iOS application (.ipa file) or android application (.apk file) to the LambdaTest servers using our REST API. You need to provide your Username and AccessKey in the format Username:AccessKey in the cURL command for authentication. Make sure to add the path of the appFile in the cURL request. Here is an example cURL request to upload your app using our REST API:
 
 Using App File:
 
 For Linux/macOS:
+
+```bash
 curl -u "YOUR_LAMBDATEST_USERNAME:YOUR_LAMBDATEST_ACCESS_KEY" \
---location --request POST '[https://manual-api.lambdatest.com/app/upload/realDevice](https://manual-api.lambdatest.com/app/upload/realDevice)' \
+--location --request POST 'https://manual-api.lambdatest.com/app/upload/realDevice' \
 --form 'name="Android_App"' \
 --form 'appFile=@"/Users/macuser/Downloads/proverbial_android.apk"'
+```
 
 For Windows:
-curl -u "YOUR_LAMBDATEST_USERNAME:YOUR_LAMBDATEST_ACCESS_KEY" -X POST "[https://manual-api.lambdatest.com/app/upload/realDevice](https://manual-api.lambdatest.com/app/upload/realDevice)" -F "appFile=@"/Users/macuser/Downloads/proverbial_android.apk""
+
+```bash
+curl -u "USER:KEY" -X POST "https://manual-api.lambdatest.com/app/upload/realDevice" -F "appFile=@"C:/path/to/proverbial_android.apk""
+```
 
 Using App URL:
 
 For Linux/macOS:
+
+```bash
 curl -u "YOUR_LAMBDATEST_USERNAME:YOUR_LAMBDATEST_ACCESS_KEY" \
---location --request POST '[https://manual-api.lambdatest.com/app/upload/realDevice](https://manual-api.lambdatest.com/app/upload/realDevice)' \
+--location --request POST 'https://manual-api.lambdatest.com/app/upload/realDevice' \
 --form 'name="Android_App"' \
---form 'url="[https://prod-mobile-artefacts.lambdatest.com/assets/docs/proverbial_android.apk](https://prod-mobile-artefacts.lambdatest.com/assets/docs/proverbial_android.apk)"'
+--form 'url="https://prod-mobile-artefacts.lambdatest.com/assets/docs/proverbial_android.apk"'
+```
 
 For Windows:
-curl -u "YOUR_LAMBDATEST_USERNAME:YOUR_LAMBDATEST_ACCESS_KEY" -X POST "[https://manual-api.lambdatest.com/app/upload/realDevice](https://manual-api.lambdatest.com/app/upload/realDevice)" -d "{"url":"[https://prod-mobile-artefacts.lambdatest.com/assets/docs/proverbial_android.apk](https://prod-mobile-artefacts.lambdatest.com/assets/docs/proverbial_android.apk)","name":"sample.apk"}"
 
-Tip: If you do not have an app file, use our sample Android app or iOS app. The response will be a JSON object containing the App URL (e.g., lt://APP12345).
+```bash
+curl -u "YOUR_LAMBDATEST_USERNAME:YOUR_LAMBDATEST_ACCESS_KEY" -X POST "https://manual-api.lambdatest.com/app/upload/realDevice" -d "{"url":"https://prod-mobile-artefacts.lambdatest.com/assets/docs/proverbial_android.apk","name":"sample.apk"}"
+```
 
+Tip:
 
-Run Your First Test
-Configuring Your Test Capabilities
-Update your custom capabilities in your test scripts (android-sample.rb or ios-sample.rb). For Ruby 3.4, you must use Symbols for keys in the driver initialization.
+1. If you do not have any .apk or .ipa file, you can run your sample tests on LambdaTest by using our sample 🔗 [Android App](https://prod-mobile-artefacts.lambdatest.com/assets/docs/proverbial_android.apk) or sample 🔗 [iOS App](https://prod-mobile-artefacts.lambdatest.com/assets/docs/proverbial_ios.ipa).
+2. Response of above cURL will be a JSON object containing the App URL of the format - lt://APP123456789123456789 and will be used in the next step.
 
-Android Config Example:
+## Run Your First Test
+
+Once you are done with the above-mentioned steps, you can initiate your first Ruby test on LambdaTest.
+
+Test Scenario: Check out [Android.rb](https://github.com/LambdaTest/LT-appium-ruby/blob/master/android/android-sample.rb) file to view the sample test script for android and [iOS.rb](https://github.com/LambdaTest/LT-appium-ruby/blob/master/ios/ios-sample.rb) for iOS.
+
+### Configuring Your Test Capabilities (Ruby 3.4/W3C Fix)
+Update the caps object in your scripts. For Ruby 3.4, keys must be Symbols.
+
+Android Configuration
+
+```bash
 caps = {
   "lt:options" => {
-    :deviceName => "Galaxy S21",
+    :deviceName => "Galaxy S24",
     :platformName => "Android",
-    :platformVersion => "11",
-    :build => "Ruby Vanilla - Android",
-    :name => "Ruby Android Test",
+    :platformVersion => "14",
     :isRealMobile => true,
-    :app => "YOUR_APP_URL", # Enter lt:// APP URL here
+    :app => "YOUR_APP_URL",
     :w3c => true
   },
   :platformName => "Android"
 }
+```
 
+iOS Configuration
 
-iOS (.ipa) Configuration:
+```bash
 caps = {
   "lt:options" => {
-    :deviceName => "iPhone 13 Pro",
+    :deviceName => "iPhone 17 Pro",
     :platformName => "iOS",
-    :platformVersion => "15",
-    :build => "Ruby Vanilla - iOS",
-    :name => "Ruby iOS Test",
+    :platformVersion => "26",
     :isRealMobile => true,
-    :app => "YOUR_APP_URL", # Enter lt:// APP URL here
+    :app => "YOUR_APP_URL",
     :w3c => true
   },
   :platformName => "iOS"
 }
+```
 
+Info Note:
 
-Executing The Tests
+1. You must add the generated APP_URL to the "app" capability in the config file.
+2. You can generate capabilities for your test requirements with the help of our inbuilt [Capabilities Generator tool](https://www.lambdatest.com/capabilities-generator/). A more Detailed Capability Guide is available [here](https://www.lambdatest.com/support/docs/desired-capabilities-in-appium/).
 
-1. Install required gems:
+## Executing The Tests
+
+1. Install dependencies:
+
+```bash
 bundle install
+```
 
-2. Run Android Test:
+2. Run the scripts:
+
+Running on Android
+
+Navigate to the corresponding directory based on your app.
+
+```bash
+cd android
+```
+
+Execute the following command to run your test on LambdaTest platform:
+
+```bash
 ruby android-sample.rb
+```
 
-3. Run iOS Test:
+Running on iOS
+
+Navigate to the corresponding directory based on your app.
+
+```bash
+cd ios
+```
+
+Execute the following command to run your test on LambdaTest platform:
+
+```bash
 ruby ios-sample.rb
+```
 
+Note: Ensure you have updated the YOUR_APP_URL in each respective file before running these commands. Your test results will be displayed on the terminal and can also be viewed in detail on the [App Automation Dashboard](https://appautomation.lambdatest.com/).
 
-Troubleshooting
-Ruby 3.4 ArgumentError
-If you encounter ArgumentError (String cannot be converted to Symbol), ensure you initialize your driver with symbols for the main keys:
+## Troubleshooting
 
+1. Ruby 3.4 ArgumentError (String to Symbol)
+
+   If you encounter an ArgumentError stating "String cannot be converted to Symbol," it is because Ruby 3.4 requires explicit symbols for the driver initialization keys. Update your initialization to include the :caps and :appium_lib symbols exactly as shown below:
+
+```bash
 @appium_driver = Appium::Driver.new({
   :caps => caps,
-  :appium_lib => { :server_url => "https://#{username}:#{accessToken}@[mobile-hub.lambdatest.com/wd/hub](https://mobile-hub.lambdatest.com/wd/hub)" }
+  :appium_lib => { :server_url => server_url }
 }, true)
+```
 
+2. Gem Installation Issues
 
-About LambdaTest
-LambdaTest is a leading test execution and orchestration platform. It allows users to run both manual and automated testing of web and mobile apps across 3000+ different browsers, operating systems, and real device combinations.
+     If you encounter an error like No such file or directory @ rb_sysopen during gem installation, you can resolve it by using administrator privileges or ensuring the directory exists:
+      
+      - macOS/Linux: Use sudo gem install appium_lib -v 10.6.0.
 
-Features
-Run Appium, Selenium, and Playwright automation tests across 3000+ real environments.
+      - Windows: Open Command Prompt as Administrator and run gem install appium_lib -v 10.6.0.
 
-Real device cloud for both Android and iOS.
+3. W3C Protocol Compatibility
 
-Blazing fast test automation with HyperExecute.
+    Ensure your capabilities object includes the :w3c => true option and wraps custom LambdaTest options inside the "lt:options" key to stay compatible with modern Appium standards.
 
-120+ third-party integrations with CI/CD tools.
+## Additional Links
 
-We are here to help you 🎧
-Got a query? We are available 24x7. Contact Us
+- [Advanced Configuration for Capabilities](https://www.lambdatest.com/support/docs/desired-capabilities-in-appium/)
+- [How to test locally hosted apps](https://www.lambdatest.com/support/docs/testing-locally-hosted-pages/)
+- [How to integrate LambdaTest with CI/CD](https://www.lambdatest.com/support/docs/integrations-with-ci-cd-tools/)
 
-Visit LambdaTest for more info.
+## Documentation & Resources 📚
 
-<img height="53" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">
+Visit the following links to learn more about LambdaTest's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
 
+ - [LambdaTest Documentation](https://www.lambdatest.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=LT-appium-ruby)
+ - [LambdaTest Blog](https://www.lambdatest.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=LT-appium-ruby)
+ - [LambdaTest Learning Hub](https://www.lambdatest.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=LT-appium-ruby)
+
+## LambdaTest Community :busts_in_silhouette:
+
+The [LambdaTest Community](https://community.lambdatest.com/) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
+
+## What's New At LambdaTest ❓
+
+To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/) 
+      
+## About LambdaTest
+
+[LambdaTest](https://www.lambdatest.com) is a leading test execution and orchestration platform that is fast, reliable, scalable, and secure. It allows users to run both manual and automated testing of web and mobile apps across 3000+ different browsers, operating systems, and real device combinations. Using LambdaTest, businesses can ensure quicker developer feedback and hence achieve faster go to market. Over 500 enterprises and 1 Million + users across 130+ countries rely on LambdaTest for their testing needs.    
+
+### Features
+
+* Run Selenium, Cypress, Puppeteer, Playwright, and Appium automation tests across 3000+ real desktop and mobile environments.
+* Real-time cross browser testing on 3000+ environments.
+* Test on Real device cloud
+* Blazing fast test automation with HyperExecute
+* Accelerate testing, shorten job times and get faster feedback on code changes with Test At Scale.
+* Smart Visual Regression Testing on cloud
+* 120+ third-party integrations with your favorite tool for CI/CD, Project Management, Codeless Automation, and more.
+* Automated Screenshot testing across multiple browsers in a single click.
+* Local testing of web and mobile apps.
+* Online Accessibility Testing across 3000+ desktop and mobile browsers, browser versions, and operating systems.
+* Geolocation testing of web and mobile apps across 53+ countries.
+* LT Browser - for responsive testing across 50+ pre-installed mobile, tablets, desktop, and laptop viewports
+    
+[<img height="53" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
+
+      
+## We are here to help you :headphones:
+
+* Got a query? we are available 24x7 to help. [Contact Us](support@lambdatest.com)
+* For more info, visit - [LambdaTest](https://www.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=LT-appium-ruby)

--- a/README.md
+++ b/README.md
@@ -29,87 +29,78 @@
 * [Executing The Tests](#executing-the-tests)
 * [Troubleshooting](#troubleshooting)
 
+---
+
 ## Pre-requisites
 
-Before you can start performing Ruby automation testing with Appium, you would need to:
+To perform Ruby automation testing with Appium on LambdaTest, you must complete the following setup:
 
-- Install **Ruby** on your local system (Ruby 3.4+ recommended).
-- For **Windows**, download from [rubyinstaller.org](https://rubyinstaller.org/downloads/).
+### 1. Install Ruby
+Install **Ruby 3.4.0** or higher on your local system.
+- **Windows**: Download and install from [RubyInstaller for Windows](https://rubyinstaller.org/downloads/).
+- **macOS**: Use Homebrew: `brew install ruby`.
+- **Linux**: Use apt: `sudo apt-get install ruby-full`.
 
-### Clone The Sample Project
-
+### 2. Install Bundler
+Bundler provides a consistent environment for Ruby projects by tracking and installing the exact gems and versions that are needed.
 ```bash
+gem install bundler
+
+3. Clone The Project
+Clone this repository to your local machine:
 git clone [https://github.com/Priya2224/LT-appium-ruby.git](https://github.com/Priya2224/LT-appium-ruby.git)
 cd LT-appium-ruby
 
-Setting Up Your Authentication
-Set LambdaTest Username and Access Key in your environment variables.
+4. Setup Authentication
+Retrieve your LambdaTest Username and Access Key from the LambdaTest Automation Dashboard. Set them as environment variables:
 
-For Windows:
+For Windows (CMD):
+set LT_USERNAME=YOUR_USERNAME
+set LT_ACCESS_KEY=YOUR_ACCESS_KEY
 
-set LT_USERNAME=YOUR_LAMBDATEST_USERNAME
-set LT_ACCESS_KEY=YOUR_LAMBDATEST_ACCESS_KEY
+For macOS/Linux:
+export LT_USERNAME=YOUR_USERNAME
+export LT_ACCESS_KEY=YOUR_ACCESS_KEY
 
-Upload Your Application
-Upload your app via cURL to get your lt:// App URL.
+Run Your First Test
+1. Upload Your App
+Upload your .apk (Android) or .ipa (iOS) file to LambdaTest to receive your App URL (lt://APP12345).
 
-For Windows:
+2. Configure Capabilities (Ruby 3.4 Fix)
+Update the caps object in your script. Note that for Ruby 3.4, you must use Symbols for driver initialization keys.
 
-curl -u "USER:KEY" -X POST "[https://manual-api.lambdatest.com/app/upload/realDevice](https://manual-api.lambdatest.com/app/upload/realDevice)" -F "appFile=@"C:/path/to/your/app.apk""Run 
-
-Your First Test
-Configuring Your Test Capabilities (W3C & Ruby 3.4 Fix)
-To prevent ArgumentError in Ruby 3.4, your Appium::Driver.new call must use Symbols for keys.
-
-Android Configuration:
-
-Ruby
 caps = {
     "lt:options" => {
         :deviceName => "Pixel 6",
         :platformName => "Android",
         :platformVersion => "13",
-        :build => "Ruby Vanilla - Android",
-        :name => "Ruby Android Test",
-        :isRealMobile => true,
-        :app => "YOUR_APP_URL",
-        :w3c => true
+        :app => "lt://YOUR_APP_ID",
+        :w3c => true,
+        :isRealMobile => true
     },
     :platformName => "Android"
 }
 
 Executing The Tests
-Navigate to your folder and run the script using bundle exec to ensure the correct environment.
+Install the required dependencies and run the sample script:
+# Install dependencies
+bundle install
 
-Run Android Test:
-
-Bash
+# Run the Android test
 bundle exec ruby android-sample.rb
-Run iOS Test:
 
-Bash
+# Run the iOS test
 bundle exec ruby ios-sample.rb
+
 Troubleshooting
-"ArgumentError: String cannot be converted to Symbol"
-This is a Ruby 3.4 specific fix. Ensure your driver is initialized like this:
+ArgumentError (String to Symbol)
+If you see an error regarding String/Symbol conversion, ensure your driver is created with explicit symbols:
 
-Ruby
-# The fix: Using :caps and :appium_lib as symbols
-appium_driver = Appium::Driver.new({
-    :caps => caps,
-    :appium_lib => {
-        :server_url => "https://#{username}:#{accessToken}@[mobile-hub.lambdatest.com/wd/hub](https://mobile-hub.lambdatest.com/wd/hub)"
-    }}, true)
-Gem Conflicts
-If you encounter No such file or directory or version mismatches:
+@appium_driver = Appium::Driver.new({ :caps => caps, :appium_lib => { :server_url => server_url } }, true)
 
-Delete Gemfile.lock.
-
-Run bundle update.
-
-Run bundle install.
-
-About LambdaTest
-LambdaTest is a leading test execution platform. It allows users to run manual and automated testing across 3000+ different browsers and real devices.
+Missing Gemfile.lock
+If you have dependency conflicts, run:
+del Gemfile.lock
+bundle update
 
 <img height="53" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">

--- a/README.md
+++ b/README.md
@@ -25,82 +25,145 @@
 ## Table of Contents
 
 * [Pre-requisites](#pre-requisites)
+* [Setting Up Your Authentication](#setting-up-your-authentication)
+* [Upload Your Application](#upload-your-application)
 * [Run Your First Test](#run-your-first-test)
 * [Executing The Tests](#executing-the-tests)
 * [Troubleshooting](#troubleshooting)
+* [About LambdaTest](#about-lambdatest)
 
 ---
 
 ## Pre-requisites
 
-To perform Ruby automation testing with Appium on LambdaTest, you must complete the following setup:
+Before you can start performing Ruby automation testing with Appium, you would need to:
 
-### 1. Install Ruby
-Install **Ruby 3.4.0** or higher on your local system.
-- **Windows**: Download and install from [RubyInstaller for Windows](https://rubyinstaller.org/downloads/).
-- **macOS**: Use Homebrew: `brew install ruby`.
-- **Linux**: Use apt: `sudo apt-get install ruby-full`.
+1. **Install Ruby**: Ensure you have Ruby 3.4+ installed.
+   - For **Windows**, download from [RubyInstaller](https://rubyinstaller.org/downloads/).
+   - For **macOS**, run `brew install ruby`.
 
-### 2. Install Bundler
-Bundler provides a consistent environment for Ruby projects by tracking and installing the exact gems and versions that are needed.
-```bash
-gem install bundler
+2. **Clone The Sample Project**:
+   ```bash
+   git clone [https://github.com/Priya2224/LT-appium-ruby.git](https://github.com/Priya2224/LT-appium-ruby.git)
+   cd LT-appium-ruby
 
-3. Clone The Project
-Clone this repository to your local machine:
-git clone [https://github.com/Priya2224/LT-appium-ruby.git](https://github.com/Priya2224/LT-appium-ruby.git)
-cd LT-appium-ruby
 
-4. Setup Authentication
-Retrieve your LambdaTest Username and Access Key from the LambdaTest Automation Dashboard. Set them as environment variables:
+Setting Up Your Authentication
+Make sure you have your LambdaTest credentials with you to run test automation scripts. To obtain your access credentials, purchase a plan or access the Automation Dashboard.
 
-For Windows (CMD):
-set LT_USERNAME=YOUR_USERNAME
-set LT_ACCESS_KEY=YOUR_ACCESS_KEY
+Set LambdaTest Username and Access Key in environment variables.
 
-For macOS/Linux:
-export LT_USERNAME=YOUR_USERNAME
-export LT_ACCESS_KEY=YOUR_ACCESS_KEY
+For Linux/macOS:
+export LT_USERNAME=YOUR_LAMBDATEST_USERNAME \
+export LT_ACCESS_KEY=YOUR_LAMBDATEST_ACCESS_KEY
+
+For Windows:
+set LT_USERNAME=YOUR_LAMBDATEST_USERNAME
+set LT_ACCESS_KEY=YOUR_LAMBDATEST_ACCESS_KEY
+
+
+Upload Your Application
+Upload your iOS application (.ipa file) or android application (.apk file) to the LambdaTest servers using our REST API.
+
+Using App File:
+
+For Linux/macOS:
+curl -u "YOUR_LAMBDATEST_USERNAME:YOUR_LAMBDATEST_ACCESS_KEY" \
+--location --request POST '[https://manual-api.lambdatest.com/app/upload/realDevice](https://manual-api.lambdatest.com/app/upload/realDevice)' \
+--form 'name="Android_App"' \
+--form 'appFile=@"/Users/macuser/Downloads/proverbial_android.apk"'
+
+For Windows:
+curl -u "YOUR_LAMBDATEST_USERNAME:YOUR_LAMBDATEST_ACCESS_KEY" -X POST "[https://manual-api.lambdatest.com/app/upload/realDevice](https://manual-api.lambdatest.com/app/upload/realDevice)" -F "appFile=@"/Users/macuser/Downloads/proverbial_android.apk""
+
+Using App URL:
+
+For Linux/macOS:
+curl -u "YOUR_LAMBDATEST_USERNAME:YOUR_LAMBDATEST_ACCESS_KEY" \
+--location --request POST '[https://manual-api.lambdatest.com/app/upload/realDevice](https://manual-api.lambdatest.com/app/upload/realDevice)' \
+--form 'name="Android_App"' \
+--form 'url="[https://prod-mobile-artefacts.lambdatest.com/assets/docs/proverbial_android.apk](https://prod-mobile-artefacts.lambdatest.com/assets/docs/proverbial_android.apk)"'
+
+For Windows:
+curl -u "YOUR_LAMBDATEST_USERNAME:YOUR_LAMBDATEST_ACCESS_KEY" -X POST "[https://manual-api.lambdatest.com/app/upload/realDevice](https://manual-api.lambdatest.com/app/upload/realDevice)" -d "{"url":"[https://prod-mobile-artefacts.lambdatest.com/assets/docs/proverbial_android.apk](https://prod-mobile-artefacts.lambdatest.com/assets/docs/proverbial_android.apk)","name":"sample.apk"}"
+
+Tip: If you do not have an app file, use our sample Android app or iOS app. The response will be a JSON object containing the App URL (e.g., lt://APP12345).
+
 
 Run Your First Test
-1. Upload Your App
-Upload your .apk (Android) or .ipa (iOS) file to LambdaTest to receive your App URL (lt://APP12345).
+Configuring Your Test Capabilities
+Update your custom capabilities in your test scripts (android-sample.rb or ios-sample.rb). For Ruby 3.4, you must use Symbols for keys in the driver initialization.
 
-2. Configure Capabilities (Ruby 3.4 Fix)
-Update the caps object in your script. Note that for Ruby 3.4, you must use Symbols for driver initialization keys.
-
+Android Config Example:
 caps = {
-    "lt:options" => {
-        :deviceName => "Pixel 6",
-        :platformName => "Android",
-        :platformVersion => "13",
-        :app => "lt://YOUR_APP_ID",
-        :w3c => true,
-        :isRealMobile => true
-    },
-    :platformName => "Android"
+  "lt:options" => {
+    :deviceName => "Galaxy S21",
+    :platformName => "Android",
+    :platformVersion => "11",
+    :build => "Ruby Vanilla - Android",
+    :name => "Ruby Android Test",
+    :isRealMobile => true,
+    :app => "YOUR_APP_URL", # Enter lt:// APP URL here
+    :w3c => true
+  },
+  :platformName => "Android"
 }
 
+
+iOS (.ipa) Configuration:
+caps = {
+  "lt:options" => {
+    :deviceName => "iPhone 13 Pro",
+    :platformName => "iOS",
+    :platformVersion => "15",
+    :build => "Ruby Vanilla - iOS",
+    :name => "Ruby iOS Test",
+    :isRealMobile => true,
+    :app => "YOUR_APP_URL", # Enter lt:// APP URL here
+    :w3c => true
+  },
+  :platformName => "iOS"
+}
+
+
 Executing The Tests
-Install the required dependencies and run the sample script:
-# Install dependencies
+
+1. Install required gems:
 bundle install
 
-# Run the Android test
-bundle exec ruby android-sample.rb
+2. Run Android Test:
+ruby android-sample.rb
 
-# Run the iOS test
-bundle exec ruby ios-sample.rb
+3. Run iOS Test:
+ruby ios-sample.rb
+
 
 Troubleshooting
-ArgumentError (String to Symbol)
-If you see an error regarding String/Symbol conversion, ensure your driver is created with explicit symbols:
+Ruby 3.4 ArgumentError
+If you encounter ArgumentError (String cannot be converted to Symbol), ensure you initialize your driver with symbols for the main keys:
 
-@appium_driver = Appium::Driver.new({ :caps => caps, :appium_lib => { :server_url => server_url } }, true)
+@appium_driver = Appium::Driver.new({
+  :caps => caps,
+  :appium_lib => { :server_url => "https://#{username}:#{accessToken}@[mobile-hub.lambdatest.com/wd/hub](https://mobile-hub.lambdatest.com/wd/hub)" }
+}, true)
 
-Missing Gemfile.lock
-If you have dependency conflicts, run:
-del Gemfile.lock
-bundle update
+
+About LambdaTest
+LambdaTest is a leading test execution and orchestration platform. It allows users to run both manual and automated testing of web and mobile apps across 3000+ different browsers, operating systems, and real device combinations.
+
+Features
+Run Appium, Selenium, and Playwright automation tests across 3000+ real environments.
+
+Real device cloud for both Android and iOS.
+
+Blazing fast test automation with HyperExecute.
+
+120+ third-party integrations with CI/CD tools.
+
+We are here to help you 🎧
+Got a query? We are available 24x7. Contact Us
+
+Visit LambdaTest for more info.
 
 <img height="53" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">
+

--- a/README.md
+++ b/README.md
@@ -17,13 +17,8 @@
   &nbsp; &#8901; &nbsp;
   <a href="https://www.youtube.com/c/LambdaTest" target="_bank">YouTube</a>
 </p>
-&emsp;
-&emsp;
-&emsp;
 
-*Appium is a tool for automating native, mobile web, and hybrid applications on iOS, Android, and Windows platforms. It supports iOS native apps written in Objective-C or Swift and Android native apps written in Java or Kotlin. It also supports mobile web apps accessed using a mobile browser (Appium supports Safari on iOS and Chrome or the built-in 'Browser' app on Android). Perform Appium automation tests on [LambdaTest's online cloud](https://www.lambdatest.com/appium-mobile-testing).*
-
-*Learn the basics of [Appium testing on the LambdaTest platform](https://www.lambdatest.com/support/docs/getting-started-with-appium-testing/).*
+*Appium is a tool for automating native, mobile web, and hybrid applications on iOS, Android, and Windows platforms. Perform Appium automation tests on [LambdaTest's online cloud](https://www.lambdatest.com/appium-mobile-testing).*
 
 [<img height="53" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
 
@@ -32,311 +27,89 @@
 * [Pre-requisites](#pre-requisites)
 * [Run Your First Test](#run-your-first-test)
 * [Executing The Tests](#executing-the-tests)
+* [Troubleshooting](#troubleshooting)
 
 ## Pre-requisites
 
 Before you can start performing Ruby automation testing with Appium, you would need to:
 
-- Install **Ruby** on your local system. Follow these instructions to install on different operating systems.
-
-  - For **Windows**, you can download from the [official website](https://rubyinstaller.org/downloads/).
-  - For **Linux** or **Ubuntu**, you can run a simple apt command like below:
-
-    ```bash
-    sudo apt-get install ruby-full
-    ```
-
-  - For **macOS**, you can run a [Homebrew](https://brew.sh/) command like this:
-
-    ```bash
-    brew install ruby
-    ```
-
+- Install **Ruby** on your local system (Ruby 3.4+ recommended).
+- For **Windows**, download from [rubyinstaller.org](https://rubyinstaller.org/downloads/).
 
 ### Clone The Sample Project
 
-Clone the LambdaTest’s [LT_Ruby_Appium](https://github.com/LambdaTest/LT_Ruby_Appium) and navigate to the code directory as shown below:
-
 ```bash
-git clone https://github.com/LambdaTest/LT_Ruby_Appium
-cd LT_Ruby_Appium
-```
+git clone [https://github.com/Priya2224/LT-appium-ruby.git](https://github.com/Priya2224/LT-appium-ruby.git)
+cd LT-appium-ruby
 
-### Setting Up Your Authentication
+Setting Up Your Authentication
+Set LambdaTest Username and Access Key in your environment variables.
 
-Make sure you have your LambdaTest credentials with you to run test automation scripts on LambdaTest. To obtain your access credentials, [purchase a plan](https://billing.lambdatest.com/billing/plans) or access the [Automation Dashboard](https://appautomation.lambdatest.com/).
+For Windows:
 
-Set LambdaTest `Username` and `Access Key` in environment variables.
-
-**For Linux/macOS:**
-
-```js
-export LT_USERNAME=YOUR_LAMBDATEST_USERNAME \
-export LT_ACCESS_KEY=YOUR_LAMBDATEST_ACCESS_KEY
-```
- 
-**For Windows:**
- 
-```js
-set LT_USERNAME=YOUR_LAMBDATEST_USERNAME `
+set LT_USERNAME=YOUR_LAMBDATEST_USERNAME
 set LT_ACCESS_KEY=YOUR_LAMBDATEST_ACCESS_KEY
-```
-  
-### Upload Your Application
 
-Upload your **_iOS_** application (.ipa file) or **_android_** application (.apk file) to the LambdaTest servers using our **REST API**. You need to provide your **Username** and **AccessKey** in the format `Username:AccessKey` in the **cURL** command for authentication. Make sure to add the path of the **appFile** in the cURL request. Here is an example cURL request to upload your app using our REST API:
+Upload Your Application
+Upload your app via cURL to get your lt:// App URL.
 
-**Using App File:**
+For Windows:
 
-**For Linux/macOS:**
+curl -u "USER:KEY" -X POST "[https://manual-api.lambdatest.com/app/upload/realDevice](https://manual-api.lambdatest.com/app/upload/realDevice)" -F "appFile=@"C:/path/to/your/app.apk""Run 
 
-```js
-curl -u "YOUR_LAMBDATEST_USERNAME:YOUR_LAMBDATEST_ACCESS_KEY" \
---location --request POST 'https://manual-api.lambdatest.com/app/upload/realDevice' \
---form 'name="Android_App"' \
---form 'appFile=@"/Users/macuser/Downloads/proverbial_android.apk"' 
-```
+Your First Test
+Configuring Your Test Capabilities (W3C & Ruby 3.4 Fix)
+To prevent ArgumentError in Ruby 3.4, your Appium::Driver.new call must use Symbols for keys.
 
-**For Windows:**
+Android Configuration:
 
-```js
-curl -u "YOUR_LAMBDATEST_USERNAME:YOUR_LAMBDATEST_ACCESS_KEY" -X POST "https://manual-api.lambdatest.com/app/upload/realDevice" -F "appFile=@"/Users/macuser/Downloads/proverbial_android.apk""
-```
-
-**Using App URL:**
-
-**For Linux/macOS:**
-
-```js
-curl -u "YOUR_LAMBDATEST_USERNAME:YOUR_LAMBDATEST_ACCESS_KEY" \
---location --request POST 'https://manual-api.lambdatest.com/app/upload/realDevice' \
---form 'name="Android_App"' \
---form 'url="https://prod-mobile-artefacts.lambdatest.com/assets/docs/proverbial_android.apk"'
-```
-
-**For Windows:**
-
-```js
-curl -u "YOUR_LAMBDATEST_USERNAME:YOUR_LAMBDATEST_ACCESS_KEY" -X POST "https://manual-api.lambdatest.com/app/upload/realDevice" -d "{"url":"https://prod-mobile-artefacts.lambdatest.com/assets/docs/proverbial_android.apk","name":"sample.apk"}"
-```
-
-**Tip:**
-
-- If you do not have any **.apk** or **.ipa** file, you can run your sample tests on LambdaTest by using our sample :link: [Android app](https://prod-mobile-artefacts.lambdatest.com/assets/docs/proverbial_android.apk) or sample :link: [iOS app](https://prod-mobile-artefacts.lambdatest.com/assets/docs/proverbial_ios.ipa).
-- Response of above cURL will be a **JSON** object containing the `App URL` of the format - <lt://APP123456789123456789> and will be used in the next step.
-
-## Run Your First Test
-
-Once you are done with the above-mentioned steps, you can initiate your first Ruby test on LambdaTest.
-
-**Test Scenario:** Check out [Android.rb](https://github.com/LambdaTest/LT-appium-ruby/blob/master/android/android-sample.rb) file to view the sample test script for android and [iOS.rb](https://github.com/LambdaTest/LT-appium-ruby/blob/master/ios/ios-sample.rb) for iOS.
-
-### Configuring Your Test Capabilities
-
-You can update your custom capabilities in test scripts. In this sample project, we are passing platform name, platform version, device name and app url (generated earlier) along with other capabilities like build name and test name via capabilities object. The capabilities object in the sample code are defined as:
-
-**Info Note:**
-
-- In case you're using the Capabilities using the JSON Wire Protocol, then please use appium_lib version 10.6.0 and below.
-- Install it using ```gem install appium_lib -v 10.6.0``` command.
-
-<Tabs className="docs__val">
-
-<TabItem value="ios-config" label="iOS" default>
-
-```ruby title="iOS(.ipa)"
- caps = {
-            "LT:Options" => {
-                :deviceName => "iPhone 13 Pro",  
-                :platformName => "iOS",
-                :platformVersion => "15",
-                :build => "Ruby Vanilla - iOS",
-                :name => "Ruby iOS Test",
-                :isRealMobile => true,
-                :app => "YOUR_APP_URL", #Enter the App (.ipa) URL here
-                :w3c => true,
-        } }
-```
-
-</TabItem>
-<TabItem value="android-config" label="Android" default>
-
-```ruby title="Android(.apk)"
+Ruby
 caps = {
-            "LT:Options" => {
-            :deviceName => "OnePlus 7",  
-            :platformName => "Android",
-            :platformVersion => "9",
-            :build => "Ruby Vanilla - Android",
-            :name => "Ruby Android Test",
-            :isRealMobile => true,
-            :app => "YOUR_APP_URL", #Enter the App (.apk) URL here
-            :w3c => true,
-        } }
-```
+    "lt:options" => {
+        :deviceName => "Pixel 6",
+        :platformName => "Android",
+        :platformVersion => "13",
+        :build => "Ruby Vanilla - Android",
+        :name => "Ruby Android Test",
+        :isRealMobile => true,
+        :app => "YOUR_APP_URL",
+        :w3c => true
+    },
+    :platformName => "Android"
+}
 
-</TabItem>
+Executing The Tests
+Navigate to your folder and run the script using bundle exec to ensure the correct environment.
 
-</Tabs>
+Run Android Test:
 
-**Info Note:**
+Bash
+bundle exec ruby android-sample.rb
+Run iOS Test:
 
-- You must add the generated **APP_URL** to the `"app"` capability in the config file.
-- You can generate capabilities for your test requirements with the help of our inbuilt **[Capabilities Generator tool](https://www.lambdatest.com/capabilities-generator/)**. A more Detailed Capability Guide is available [here](https://www.lambdatest.com/support/docs/desired-capabilities-in-appium/).
+Bash
+bundle exec ruby ios-sample.rb
+Troubleshooting
+"ArgumentError: String cannot be converted to Symbol"
+This is a Ruby 3.4 specific fix. Ensure your driver is initialized like this:
 
-## Executing The Tests
+Ruby
+# The fix: Using :caps and :appium_lib as symbols
+appium_driver = Appium::Driver.new({
+    :caps => caps,
+    :appium_lib => {
+        :server_url => "https://#{username}:#{accessToken}@[mobile-hub.lambdatest.com/wd/hub](https://mobile-hub.lambdatest.com/wd/hub)"
+    }}, true)
+Gem Conflicts
+If you encounter No such file or directory or version mismatches:
 
-<Tabs className="docs__val">
+Delete Gemfile.lock.
 
-<TabItem value="ios" label="iOS" default>
+Run bundle update.
 
-If you are using an **iOS** app, the cURL command will generate an app URL for the corresponding iOS app and install the same for running the tests. You can either use our sample :link: [iOS app](https://prod-mobile-artefacts.lambdatest.com/assets/docs/proverbial_ios.ipa) or upload your own app as discussed earlier.
+Run bundle install.
 
-Navigate to the corresponding directory based on your app.
+About LambdaTest
+LambdaTest is a leading test execution platform. It allows users to run manual and automated testing across 3000+ different browsers and real devices.
 
-```bash
-cd ios
-```
-
-Execute the following command to run your test on LambdaTest platform:
-
-```bash
-ruby ios-sample.rb
-```
-
-</TabItem>
-
-<TabItem value="android" label="Android" default>
-
-If you are using an **android** app, the cURL command will generate an app URL for the corresponding Android app and install the same for running the tests. You can either use our sample :link: [Android app](https://prod-mobile-artefacts.lambdatest.com/assets/docs/proverbial_android.apk) or upload your own app as discussed earlier.
-
-Navigate to the corresponding directory based on your app.
-
-```bash
-cd android
-```
-
-Execute the following command to run your test on LambdaTest platform:
-
-```bash
-ruby android-sample.rb
-```
-
-</TabItem>
-
-</Tabs>
-
-**Info Note**
-In case of Windows, if you get any error message. Please try this method:
-
-1. Navigate to the corresponding directory based on your app.
-
-```bash
-cd android
-```
-2. Refresh the gem bundles through given command
-
-```bash
-gem uninstall -aIx
-```
-3. Re-install the gems required
-
-```bash
-gem install appium_lib -v 10.6.0
-gem install ffi
-```
-4. Now try running the corresponding automation script for your app.
-
-```bash
-ruby android-sample.rb
-```
-
-**Info:** Your test results would be displayed on the test console (or command-line interface if you are using terminal/cmd) and on the :link: [LambdaTest App Automation Dashboard](https://appautomation.lambdatest.com/build).
-
-### Troubleshooting
-
-If you encounter an issue where the gem installation fails with an error like `No such file or directory @ rb_sysopen`, you can resolve it by creating the required directory, setting up a custom gem path, or installing with administrator privileges.
-
-#### Option 1: Create the Missing Directory
-
-**macOS/Linux:**  
-Run the following command to create the required directory structure:
-```bash
-mkdir -p ~/.local/share/gem/ruby/<ruby_version>/cache
-```
-**Windows:**
-```bash
-mkdir -p %USERPROFILE%\.gem\ruby\<ruby version>\cache
-```
-#### Option 2: Set a Custom GEM Path
-**macOS/Linux:**
-```bash
-export GEM_HOME=$HOME/gems
-export PATH=$HOME/gems/bin:$PATH
-gem install appium_lib -v 10.6.0
-```
-**Windows:**
-```bash
-set GEM_HOME=%USERPROFILE%\gems
-set PATH=%USERPROFILE%\gems\bin;%PATH%
-gem install appium_lib -v 10.6.0
-```
-#### Option 3: Install with Administrator Privileges
-**macOS/Linux:**
-```bash
-sudo gem install appium_lib -v 10.6.0
-```
-**Windows:**
-Run Command Prompt as Administrator, then:
-```bash
-gem install appium_lib -v 10.6.0
-``` 
-
-## Additional Links
-
-- [Advanced Configuration for Capabilities](https://www.lambdatest.com/support/docs/desired-capabilities-in-appium/)
-- [How to test locally hosted apps](https://www.lambdatest.com/support/docs/testing-locally-hosted-pages/)
-- [How to integrate LambdaTest with CI/CD](https://www.lambdatest.com/support/docs/integrations-with-ci-cd-tools/)
-
-## Documentation & Resources :books:
-      
-Visit the following links to learn more about LambdaTest's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
-
-* [LambdaTest Documentation](https://www.lambdatest.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=LT-appium-ruby)
-* [LambdaTest Blog](https://www.lambdatest.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=LT-appium-ruby)
-* [LambdaTest Learning Hub](https://www.lambdatest.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=LT-appium-ruby)    
-
-## LambdaTest Community :busts_in_silhouette:
-
-The [LambdaTest Community](https://community.lambdatest.com/) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
-
-## What's New At LambdaTest ❓
-
-To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/) 
-      
-## About LambdaTest
-
-[LambdaTest](https://www.lambdatest.com) is a leading test execution and orchestration platform that is fast, reliable, scalable, and secure. It allows users to run both manual and automated testing of web and mobile apps across 3000+ different browsers, operating systems, and real device combinations. Using LambdaTest, businesses can ensure quicker developer feedback and hence achieve faster go to market. Over 500 enterprises and 1 Million + users across 130+ countries rely on LambdaTest for their testing needs.    
-
-### Features
-
-* Run Selenium, Cypress, Puppeteer, Playwright, and Appium automation tests across 3000+ real desktop and mobile environments.
-* Real-time cross browser testing on 3000+ environments.
-* Test on Real device cloud
-* Blazing fast test automation with HyperExecute
-* Accelerate testing, shorten job times and get faster feedback on code changes with Test At Scale.
-* Smart Visual Regression Testing on cloud
-* 120+ third-party integrations with your favorite tool for CI/CD, Project Management, Codeless Automation, and more.
-* Automated Screenshot testing across multiple browsers in a single click.
-* Local testing of web and mobile apps.
-* Online Accessibility Testing across 3000+ desktop and mobile browsers, browser versions, and operating systems.
-* Geolocation testing of web and mobile apps across 53+ countries.
-* LT Browser - for responsive testing across 50+ pre-installed mobile, tablets, desktop, and laptop viewports
-    
-[<img height="53" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
-
-      
-## We are here to help you :headphones:
-
-* Got a query? we are available 24x7 to help. [Contact Us](support@lambdatest.com)
-* For more info, visit - [LambdaTest](https://www.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=LT-appium-ruby)
+<img height="53" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">

--- a/android/android-sample.rb
+++ b/android/android-sample.rb
@@ -6,9 +6,9 @@ accessToken= ENV["LT_ACCESS_KEY"] || "LT_AccessKey" # Enter your Access Key here
 
 caps = {
     "lt:options" => {
-        :deviceName => "Pixel 6",
+        :deviceName => "Galaxy S24",
         :platformName => "Android",
-        :platformVersion => "13",
+        :platformVersion => "14",
         :build => "Ruby Vanilla - Android",
         :name => "Ruby Android Test",
         :isRealMobile => true,

--- a/android/android-sample.rb
+++ b/android/android-sample.rb
@@ -1,51 +1,51 @@
 require 'rubygems'
 require 'appium_lib'
 
-username= ENV["LT_USERNAME"] || "LT_Username" #Enter your username here
-accessToken= ENV["LT_ACCESS_KEY"] || "LT_AccessKey" #Enter your Access Key here
+username= ENV["LT_USERNAME"] || "LT_Username" # Enter your username here
+accessToken= ENV["LT_ACCESS_KEY"] || "LT_AccessKey" # Enter your Access Key here
 
-caps = {     
-    "lt:options" => {      
-        :deviceName => "Pixel 6",  
+caps = {
+    "lt:options" => {
+        :deviceName => "Pixel 6",
         :platformName => "Android",
         :platformVersion => "13",
         :build => "Ruby Vanilla - Android",
         :name => "Ruby Android Test",
         :isRealMobile => true,
         :queueTimeout => 300,
-        :app => "lt://proverbial-android", #Enter the App URL here
+        :app => "lt://proverbial-android", # Enter the App URL here
         :w3c => true
     },
     :platformName => "Android"
 }
 
+# The fix is here: Changed 'caps' to :caps and 'appium_lib' to :appium_lib
 appium_driver = Appium::Driver.new({
-    'caps' => caps,
-    'appium_lib' => {
+    :caps => caps,
+    :appium_lib => {
         :server_url => "https://"+username+":"+accessToken+"@mobile-hub.lambdatest.com/wd/hub"
-    }},true)
+    }}, true)
 
-    driver = appium_driver.start_driver
+driver = appium_driver.start_driver
 
-    wait = Selenium::WebDriver::Wait.new(:timeout => 30)
-    el1 = driver.find_element(:id, "com.lambdatest.proverbial:id/color")
-    el1.click
-    el2 = driver.find_element(:id, "com.lambdatest.proverbial:id/geoLocation")
-    el2.click
-    sleep(5)
-    driver.back
-    el3 = driver.find_element(:id, "com.lambdatest.proverbial:id/Text")
-    el3.click
-    el4 = driver.find_element(:id, "com.lambdatest.proverbial:id/notification")
-    el4.click
-    el5 = driver.find_element(:id, "com.lambdatest.proverbial:id/toast")
-    el5.click
-    el6 = driver.find_element(:id, "com.lambdatest.proverbial:id/speedTest")
-    el6.click
-    sleep(10)
-    driver.back
-    
-    puts "Found results - Test Passed"
+wait = Selenium::WebDriver::Wait.new(:timeout => 30)
+el1 = driver.find_element(:id, "com.lambdatest.proverbial:id/color")
+el1.click
+el2 = driver.find_element(:id, "com.lambdatest.proverbial:id/geoLocation")
+el2.click
+sleep(5)
+driver.back
+el3 = driver.find_element(:id, "com.lambdatest.proverbial:id/Text")
+el3.click
+el4 = driver.find_element(:id, "com.lambdatest.proverbial:id/notification")
+el4.click
+el5 = driver.find_element(:id, "com.lambdatest.proverbial:id/toast")
+el5.click
+el6 = driver.find_element(:id, "com.lambdatest.proverbial:id/speedTest")
+el6.click
+sleep(10)
+driver.back
 
-    
-    driver.quit
+puts "Found results - Test Passed"
+
+driver.quit


### PR DESCRIPTION
1.  Added `Gemfile` & `Gemfile.lock`:
    * Standardized dependencies.
    * Added `appium_lib`, `selenium-webdriver`, and `test-unit`.
2.  Updated `android/android-sample.rb`:**
    * Refactored the `Appium::Driver` initialization to use Symbols (e.g., `:caps`, `:appium_lib`) instead of Strings. This fixes compatibility with the latest `appium_lib` version.
    * Ensured the driver correctly points to the LambdaTest Hub URL instead of localhost.
